### PR TITLE
Admin products: fetch product details and persist main image & collection on edit

### DIFF
--- a/app/admin/products/page.tsx
+++ b/app/admin/products/page.tsx
@@ -15,6 +15,16 @@ type Product = {
   image: string;
 };
 
+type ProductEditData = {
+  id: string;
+  name: string;
+  price: number;
+  categoryId: string | null;
+  collectionId: string | null;
+  description: string | null;
+  imageUrl: string | null;
+};
+
 type Collection = {
   id: string;
   title?: string;
@@ -36,14 +46,16 @@ export default function AdminProductsPage() {
   const [editing, setEditing] = useState<Product | null>(null);
   const [showForm, setShowForm] = useState(false);
 
-  const [form, setForm] = useState({
+  const emptyForm = {
     name: "",
     price: "",
     categoryId: "",
     collectionId: "",
     description: "",
     imageUrl: "",
-  });
+  };
+
+  const [form, setForm] = useState(emptyForm);
 
   useEffect(() => {
     if (!isAuth || !roles.includes("admin")) {
@@ -84,14 +96,7 @@ export default function AdminProductsPage() {
     if (res.ok) {
       setShowForm(false);
       setEditing(null);
-      setForm({
-        name: "",
-        price: "",
-        categoryId: "",
-        collectionId: "",
-        description: "",
-        imageUrl: "",
-      });
+      setForm(emptyForm);
       const productsRes = await fetch("/api/products");
       const data = await productsRes.json();
       setProducts(data || []);
@@ -116,17 +121,39 @@ export default function AdminProductsPage() {
     }
   };
 
-  const handleEdit = (product: Product) => {
-    setEditing(product);
-    setForm({
+  const handleEdit = async (product: Product) => {
+    if (!accessToken) return;
+
+    const fallbackForm = {
       name: product.name,
       price: String(product.price),
       categoryId: "",
       collectionId: "",
       description: "",
-      imageUrl: product.image,
-    });
+      imageUrl: product.image === "/placeholder.png" ? "" : product.image,
+    };
+
+    setEditing(product);
+    setForm(fallbackForm);
     setShowForm(true);
+
+    const res = await fetch(`/api/admin/products?id=${product.id}`, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+
+    if (!res.ok) return;
+
+    const data = (await res.json()) as ProductEditData;
+    setForm({
+      name: data.name || "",
+      price: String(data.price ?? ""),
+      categoryId: data.categoryId || "",
+      collectionId: data.collectionId || "",
+      description: data.description || "",
+      imageUrl: data.imageUrl || "",
+    });
   };
 
   if (loading) {
@@ -152,7 +179,15 @@ export default function AdminProductsPage() {
       <div className={styles.container}>
         <div className={styles.header}>
           <h1>Управление товарами</h1>
-          <Button onClick={() => setShowForm(true)}>Добавить товар</Button>
+          <Button
+            onClick={() => {
+              setEditing(null);
+              setForm(emptyForm);
+              setShowForm(true);
+            }}
+          >
+            Добавить товар
+          </Button>
         </div>
 
         {showForm && (
@@ -242,6 +277,7 @@ export default function AdminProductsPage() {
                 onClick={() => {
                   setShowForm(false);
                   setEditing(null);
+                  setForm(emptyForm);
                 }}
               >
                 Отмена

--- a/app/api/admin/products/route.ts
+++ b/app/api/admin/products/route.ts
@@ -2,6 +2,65 @@ import pool from "@/lib/db";
 import { NextResponse } from "next/server";
 import { authenticateRequest } from "@/lib/utils/auth-guard";
 
+export async function GET(request: Request) {
+  const auth = authenticateRequest(request, ["admin"]);
+  if (!auth.ok) {
+    return auth.response;
+  }
+
+  const { searchParams } = new URL(request.url);
+  const id = searchParams.get("id");
+
+  if (!id) {
+    return NextResponse.json({ error: "id is required" }, { status: 400 });
+  }
+
+  try {
+    const result = await pool.query(
+      `SELECT
+         p.id::text AS id,
+         p.name,
+         p.price,
+         p.category_id::text AS "categoryId",
+         p.description,
+         pi.image_url AS "imageUrl",
+         pc.collection_id::text AS "collectionId"
+       FROM products p
+       LEFT JOIN LATERAL (
+         SELECT image_url
+         FROM product_images
+         WHERE product_id = p.id AND is_main = true
+         LIMIT 1
+       ) pi ON true
+       LEFT JOIN LATERAL (
+         SELECT collection_id
+         FROM product_collections
+         WHERE product_id = p.id
+         LIMIT 1
+       ) pc ON true
+       WHERE p.id::text = $1`,
+      [id],
+    );
+
+    if (result.rows.length === 0) {
+      return NextResponse.json({ error: "Товар не найден" }, { status: 404 });
+    }
+
+    const product = result.rows[0];
+
+    return NextResponse.json({
+      ...product,
+      price: Number(product.price),
+    });
+  } catch (error) {
+    console.error("GET ADMIN PRODUCT ERROR:", error);
+    return NextResponse.json(
+      { error: "Ошибка загрузки товара" },
+      { status: 500 },
+    );
+  }
+}
+
 export async function POST(request: Request) {
   const auth = authenticateRequest(request, ["admin"]);
   if (!auth.ok) {
@@ -75,12 +134,20 @@ export async function PATCH(request: Request) {
 
   try {
     const body = await request.json();
-    const { id, name, price, categoryId, description, imageUrl } = body;
+    const {
+      id,
+      name,
+      price,
+      categoryId,
+      collectionId,
+      description,
+      imageUrl,
+    } = body;
 
     if (!id || !name) {
       return NextResponse.json(
         { error: "id and name are required" },
-        { status: 400 }
+        { status: 400 },
       );
     }
 
@@ -89,19 +156,53 @@ export async function PATCH(request: Request) {
     try {
       await client.query("BEGIN");
 
-      await client.query(
+      const productResult = await client.query(
         `UPDATE products 
          SET name = $1, price = $2, category_id = $3, description = $4
-         WHERE id::text = $5`,
-        [name, price, categoryId || null, description || null, id]
+         WHERE id::text = $5
+         RETURNING id`,
+        [name, price, categoryId || null, description || null, id],
       );
 
+      if (productResult.rows.length === 0) {
+        await client.query("ROLLBACK");
+        return NextResponse.json({ error: "Товар не найден" }, { status: 404 });
+      }
+
       if (imageUrl) {
-        await client.query(
-          `UPDATE product_images 
+        const imageResult = await client.query(
+          `UPDATE product_images
            SET image_url = $1
            WHERE product_id::text = $2 AND is_main = true`,
-          [imageUrl, id]
+          [imageUrl, id],
+        );
+
+        if (imageResult.rowCount === 0) {
+          await client.query(
+            `INSERT INTO product_images (product_id, image_url, is_main)
+             VALUES ($1, $2, true)`,
+            [productResult.rows[0].id, imageUrl],
+          );
+        }
+      } else {
+        await client.query(
+          `DELETE FROM product_images
+           WHERE product_id::text = $1 AND is_main = true`,
+          [id],
+        );
+      }
+
+      await client.query(
+        `DELETE FROM product_collections
+         WHERE product_id::text = $1`,
+        [id],
+      );
+
+      if (collectionId) {
+        await client.query(
+          `INSERT INTO product_collections (product_id, collection_id)
+           VALUES ($1, $2)`,
+          [productResult.rows[0].id, collectionId],
         );
       }
 
@@ -118,7 +219,7 @@ export async function PATCH(request: Request) {
     console.error("UPDATE PRODUCT ERROR:", error);
     return NextResponse.json(
       { error: "Ошибка обновления товара" },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }


### PR DESCRIPTION
### Motivation
- Provide a way to load full product data into the admin edit form so admins can edit category, collection, description and main image. 
- Ensure `PATCH` persists changes to the product's main image and collection relationship rather than only updating the product row.

### Description
- Client: introduced `ProductEditData` and `emptyForm`, initialized `form` from `emptyForm`, and reset the form when opening the add form or cancelling. 
- Client: made `handleEdit` asynchronous and implemented a GET call to `/api/admin/products?id=...` to populate the edit form with `name`, `price`, `categoryId`, `collectionId`, `description`, and `imageUrl`, with a fallback while loading. 
- Server: added `GET` handler in `app/api/admin/products/route.ts` to return product details including main image (`product_images`) and first collection (`product_collections`) with authentication. 
- Server: extended `PATCH` to accept `collectionId`, return the updated product id, insert/update/delete the main `product_images` row as needed, and recreate the `product_collections` entry for the product.

### Testing
- Exercised the admin product edit flow manually against the local dev server to verify GET populates the form and `PATCH` updates product row, main image and collection successfully. 
- No new automated tests were added for these changes; local lint/build and existing test suite were run and completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa958c4274832eaa58082393f01ceb)